### PR TITLE
Fix for https://nvd.nist.gov/vuln/detail/CVE-2022-25350

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ var exec = require('child_process').exec;
 var getFact = function(factName, cb, options) {
   var options = options || {};
 
+  // Sanitize the input to prevent command injection
+  if (!/^[a-zA-Z0-9_]+$/.test(factName) && factName !== 'all') {
+    return cb(new Error('Invalid fact name'));
+  }
+
   if (factName == 'all') {
     factName = '';
   }


### PR DESCRIPTION
Only allow Alphanumeric with underscores single word as fact name.